### PR TITLE
fix: `ReverseWorkbench` block will drop correctly when removed

### DIFF
--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "reversecraftreimagined:reverseworkbench"
+  ]
+}

--- a/src/generated/resources/data/reversecraftreimagined/loot_tables/blocks/reverseworkbench.json
+++ b/src/generated/resources/data/reversecraftreimagined/loot_tables/blocks/reverseworkbench.json
@@ -1,0 +1,27 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
+          "name": "reversecraftreimagined:reverseworkbench"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "reversecraftreimagined:blocks/reverseworkbench"
+}

--- a/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/DataGenerators.java
+++ b/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/DataGenerators.java
@@ -1,6 +1,7 @@
 package org.cheeredadventure.reversecraftreimagined.internal;
 
 import net.minecraft.data.DataGenerator;
+import net.minecraft.data.PackOutput;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -13,22 +14,22 @@ public class DataGenerators {
   @SubscribeEvent
   public static void gatherData(GatherDataEvent event) {
     DataGenerator generator = event.getGenerator();
+    PackOutput packOutput = generator.getPackOutput();
 
-    generator.addProvider(event.includeServer(),
-      new ReverseCraftRecipeProvider(generator.getPackOutput()));
+    generator.addProvider(event.includeServer(), new ReverseCraftRecipeProvider(packOutput));
     generator.addProvider(event.includeClient(),
-      new ReverseCraftLangProvider.ReverseCraftLangUS(generator.getPackOutput()));
+      new ReverseCraftLangProvider.ReverseCraftLangUS(packOutput));
     generator.addProvider(event.includeClient(),
-      new ReverseCraftLangProvider.ReverseCraftLangJP(generator.getPackOutput()));
+      new ReverseCraftLangProvider.ReverseCraftLangJP(packOutput));
 
     ExistingFileHelper fileHelper = event.getExistingFileHelper();
     generator.addProvider(event.includeClient(),
-      new ReverseWorkbenchBlockStateProvider(generator.getPackOutput(), fileHelper));
-    generator.addProvider(event.includeServer(), new ReverseWorkbenchBlockTagsProvider(
-      generator.getPackOutput(), event.getLookupProvider(), fileHelper
+      new ReverseWorkbenchBlockStateProvider(packOutput, fileHelper));
+    generator.addProvider(event.includeServer(), new ReverseWorkbenchBlockTagsProvider(packOutput,
+      event.getLookupProvider(), fileHelper
     ));
     generator.addProvider(event.includeServer(), new ReverseWorkbenchBlockLootTableProvider(
-      generator.getPackOutput()
+      packOutput
     ));
   }
 }

--- a/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/DataGenerators.java
+++ b/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/DataGenerators.java
@@ -24,5 +24,11 @@ public class DataGenerators {
     ExistingFileHelper fileHelper = event.getExistingFileHelper();
     generator.addProvider(event.includeClient(),
       new ReverseWorkbenchBlockStateProvider(generator.getPackOutput(), fileHelper));
+    generator.addProvider(event.includeServer(), new ReverseWorkbenchBlockTagsProvider(
+      generator.getPackOutput(), event.getLookupProvider(), fileHelper
+    ));
+    generator.addProvider(event.includeServer(), new ReverseWorkbenchBlockLootTableProvider(
+      generator.getPackOutput()
+    ));
   }
 }

--- a/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/ReverseWorkbenchBlockLootTableProvider.java
+++ b/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/ReverseWorkbenchBlockLootTableProvider.java
@@ -1,0 +1,31 @@
+package org.cheeredadventure.reversecraftreimagined.internal;
+
+import java.util.Collections;
+import java.util.List;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.loot.BlockLootSubProvider;
+import net.minecraft.data.loot.LootTableProvider;
+import net.minecraft.world.flag.FeatureFlags;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import org.cheeredadventure.reversecraftreimagined.api.BlockInit;
+
+public class ReverseWorkbenchBlockLootTableProvider extends LootTableProvider {
+
+  public ReverseWorkbenchBlockLootTableProvider(PackOutput pOutput) {
+    super(pOutput, Collections.emptySet(), List.of(
+      new SubProviderEntry(ReverseWorkbenchBlockLootTableSubProvider::new,
+        LootContextParamSets.BLOCK)));
+  }
+
+  private static class ReverseWorkbenchBlockLootTableSubProvider extends BlockLootSubProvider {
+
+    protected ReverseWorkbenchBlockLootTableSubProvider() {
+      super(Collections.emptySet(), FeatureFlags.REGISTRY.allFlags());
+    }
+
+    @Override
+    protected void generate() {
+      this.add(BlockInit.getREVERSE_WORKBENCH().get(), this::createSingleItemTable);
+    }
+  }
+}

--- a/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/ReverseWorkbenchBlockLootTableProvider.java
+++ b/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/ReverseWorkbenchBlockLootTableProvider.java
@@ -2,11 +2,14 @@ package org.cheeredadventure.reversecraftreimagined.internal;
 
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nonnull;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.loot.BlockLootSubProvider;
 import net.minecraft.data.loot.LootTableProvider;
 import net.minecraft.world.flag.FeatureFlags;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import net.minecraftforge.registries.RegistryObject;
 import org.cheeredadventure.reversecraftreimagined.api.BlockInit;
 
 public class ReverseWorkbenchBlockLootTableProvider extends LootTableProvider {
@@ -25,7 +28,16 @@ public class ReverseWorkbenchBlockLootTableProvider extends LootTableProvider {
 
     @Override
     protected void generate() {
-      this.add(BlockInit.getREVERSE_WORKBENCH().get(), this::createSingleItemTable);
+      this.add(BlockInit.getREVERSE_WORKBENCH().get(), this::createNameableBlockEntityTable);
+    }
+
+    @Override
+    @Nonnull
+    protected Iterable<Block> getKnownBlocks() {
+      return BlockInit.BLOCKS.getEntries()
+        .stream()
+        .flatMap(RegistryObject::stream)
+        ::iterator;
     }
   }
 }

--- a/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/ReverseWorkbenchBlockTagsProvider.java
+++ b/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/ReverseWorkbenchBlockTagsProvider.java
@@ -1,0 +1,27 @@
+package org.cheeredadventure.reversecraftreimagined.internal;
+
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import net.minecraft.core.HolderLookup.Provider;
+import net.minecraft.data.PackOutput;
+import net.minecraft.tags.BlockTags;
+import net.minecraftforge.common.data.BlockTagsProvider;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import org.cheeredadventure.reversecraftreimagined.ReverseCraftReimagined;
+import org.cheeredadventure.reversecraftreimagined.api.BlockInit;
+import org.jetbrains.annotations.Nullable;
+
+public class ReverseWorkbenchBlockTagsProvider extends BlockTagsProvider {
+
+  public ReverseWorkbenchBlockTagsProvider(PackOutput output,
+    CompletableFuture<Provider> lookupProvider,
+    @Nullable ExistingFileHelper existingFileHelper) {
+    super(output, lookupProvider, ReverseCraftReimagined.MODID, existingFileHelper);
+  }
+
+  @Override
+  protected void addTags(@Nonnull Provider pProvider) {
+    this.tag(BlockTags.MINEABLE_WITH_AXE)
+      .add(BlockInit.getREVERSE_WORKBENCH().get());
+  }
+}


### PR DESCRIPTION
closes: #9 

- Added `LootTable` to tell minecraft to drop itemized block.
- Added `mineable_axe` tag to tell `ReverseWorkbench` block to be broken by axe.
