### PR TITLE
fix: use same breaking particle when player attempts to break the block

### DIFF
--- a/src/generated/resources/assets/reversecraftreimagined/models/block/reverseworkbench.json
+++ b/src/generated/resources/assets/reversecraftreimagined/models/block/reverseworkbench.json
@@ -4,6 +4,7 @@
     "down": "minecraft:block/oak_planks",
     "east": "minecraft:block/crafting_table_front",
     "north": "minecraft:block/crafting_table_side",
+    "particle": "minecraft:block/oak_planks",
     "south": "minecraft:block/crafting_table_front",
     "up": "minecraft:block/crafting_table_top",
     "west": "minecraft:block/crafting_table_side"

--- a/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/ReverseWorkbenchBlockStateProvider.java
+++ b/src/main/java/org/cheeredadventure/reversecraftreimagined/internal/ReverseWorkbenchBlockStateProvider.java
@@ -24,6 +24,7 @@ public class ReverseWorkbenchBlockStateProvider extends BlockStateProvider {
           mcLoc("block/crafting_table_side"),
           mcLoc("block/crafting_table_front"),
           mcLoc("block/crafting_table_front"),
-          mcLoc("block/crafting_table_side")));
+          mcLoc("block/crafting_table_side"))
+        .texture("particle", mcLoc("block/oak_planks")));
   }
 }


### PR DESCRIPTION
closes: N/A

- Added texture configuration to use same particle effect as oak planks when block is breaking.